### PR TITLE
Fix: Populate Data on Page Load using window.onload

### DIFF
--- a/scripts/education.js
+++ b/scripts/education.js
@@ -28,6 +28,8 @@ async function getEducation() {
     });
 }
 
-getEducation().catch(error => {
-    console.error(error);
+window.addEventListener("load", function() {
+    getEducation().catch(error => {
+        console.error(error);
+    });
 });

--- a/scripts/experience.js
+++ b/scripts/experience.js
@@ -75,8 +75,10 @@ async function getExperience() {
     });
 }
 
-getExperience().catch(error => {
-    console.error(error);
+window.addEventListener("load", function() {
+    getExperience().catch(error => {
+        console.error(error);
+    });
 });
 
 /**

--- a/scripts/honors-and-awards.js
+++ b/scripts/honors-and-awards.js
@@ -32,8 +32,10 @@ async function getHonorsAndAwards() {
     });
 }
 
-getHonorsAndAwards().catch(error => {
-    console.error(error);
+window.addEventListener("load", function() {
+    getHonorsAndAwards().catch(error => {
+        console.error(error);
+    });
 });
 
 /**

--- a/scripts/projects.js
+++ b/scripts/projects.js
@@ -31,6 +31,8 @@ async function getProjects() {
     });
 }
 
-getProjects().catch(error => {
-    console.error(error);
+window.addEventListener("load", function() {
+    getProjects().catch(error => {
+        console.error(error);
+    });
 });


### PR DESCRIPTION
This pull request adds `window.onload` event listener to the `getProjects()` function to ensure that the data fetched from an external JSON file is populated into the page only after the page is fully loaded. Previously, the data was not being populated into the page until the page was refreshed, which was causing confusion among users.

With this update, users can now expect to see the data on the page as soon as they access it.